### PR TITLE
matlab/ps_plot_tca.m: Remove keyboard command

### DIFF
--- a/matlab/ps_plot_tca.m
+++ b/matlab/ps_plot_tca.m
@@ -22,8 +22,6 @@ if ischar(aps_flag)
    if strcmp(aps_flag,'a_linear')==1 || strcmp(aps_flag,'a_l')==1
        % aps topo correlated linear correction
        aps_flag=1;
-       
-       keyboard
    elseif strcmp(aps_flag,'a_powerlaw')==1 || strcmp(aps_flag,'a_p')==1
        % aps topo correlated powerlaw correction
        aps_flag=2;


### PR DESCRIPTION
When using the `aps_linear` command as part of the TRAIN module the processing will freeze because of a `keyboard` command. The analysis can be continued by typing in "dbcont" but it is not obvious and often confused people.

More info here:
https://www.mathworks.com/help/matlab/ref/keyboard.html